### PR TITLE
Add typings for Typescript compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ client
 ```
 
 
+### With Typescript
+
+```typescript
+import {code as dragAndDrop} from 'html-dnd';
+
+driver.executeScript(dragAndDrop, draggable, droppable);
+```
+
+
 See also
 --------
 

--- a/html-dnd.d.ts
+++ b/html-dnd.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for html-dnd
+// Project: https://github.com/Kuniwak/html-dnd
+// Definitions by: Adrien Vergé <https://github.com/adrienverge>
+
+declare module 'html-dnd' {
+    var htmlDnd: {
+        code: string,
+        codeForSelectors: string,
+    };
+    export = htmlDnd;
+}

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
   "bugs": {
     "url": "https://github.com/Kuniwak/html-dnd/issues"
   },
+  "typings": "html-dnd.d.ts",
   "homepage": "https://github.com/Kuniwak/html-dnd#readme"
 }


### PR DESCRIPTION
Add typings to the package, so Typescript programs can directly import this library as a module and use it with:

```ts
import {code as dragAndDrop} from 'html-dnd';

driver.executeScript(dragAndDrop, draggable, droppable);
```

Also update docs accordingly.