### PR TITLE
Emit dragover event before drop

### DIFF
--- a/src/html_dnd.ts
+++ b/src/html_dnd.ts
@@ -16,6 +16,9 @@ namespace dnd {
     // read, including the data. No new data can be added.
     store.mode = "readonly";
 
+    const dragOverEvent = createEventWithDataTransfer("dragover", dataTransfer);
+    droppable.dispatchEvent(dragOverEvent);
+
     const dropEvent = createEventWithDataTransfer("drop", dataTransfer);
     droppable.dispatchEvent(dropEvent);
 


### PR DESCRIPTION
With real browsers, `dragover` events are issued before the final `drop`
(simply because the mouse passes over the drop area). Some drag'n'drop
libraries rely on this to allow / disallow drop to certain places.

This patch adds this functionality, so these libs work OK when used with
html-dnd.

Kudos to John Reynolds for his first implementation at
https://github.com/PloughingAByteField/html-dnd/commit/31872b

Closes: #14