### PR TITLE
Handing over the dragover and drop event to the event queue.

### DIFF
--- a/src/html_dnd.ts
+++ b/src/html_dnd.ts
@@ -12,23 +12,26 @@ namespace dnd {
     const dragstartEvent = createEventWithDataTransfer("dragstart", dataTransfer);
     draggable.dispatchEvent(dragstartEvent);
 
-    // For the drop event. The list of items representing dragged data can be
-    // read, including the data. No new data can be added.
-    store.mode = "readonly";
-
-    const dragOverEvent = createEventWithDataTransfer("dragover", dataTransfer);
-    droppable.dispatchEvent(dragOverEvent);
-
-    const dropEvent = createEventWithDataTransfer("drop", dataTransfer);
-    droppable.dispatchEvent(dropEvent);
-
-    // For all other events. The formats and kinds in the drag data store list
-    // of items representing dragged data can be enumerated, but the data itself
-    // is unavailable and no new data can be added.
-    store.mode = "protected";
-
-    const dragendEvent = createEventWithDataTransfer("dragend", dataTransfer);
-    draggable.dispatchEvent(dragendEvent);
+    // Handing over the dragover and drop event to the event queue.
+    setTimeout(() => {
+      // For the drop event. The list of items representing dragged data can be
+      // read, including the data. No new data can be added.
+      store.mode = "readonly";
+  
+      const dragOverEvent = createEventWithDataTransfer("dragover", dataTransfer);
+      droppable.dispatchEvent(dragOverEvent);
+  
+      const dropEvent = createEventWithDataTransfer("drop", dataTransfer);
+      droppable.dispatchEvent(dropEvent);
+  
+      // For all other events. The formats and kinds in the drag data store list
+      // of items representing dragged data can be enumerated, but the data itself
+      // is unavailable and no new data can be added.
+      store.mode = "protected";
+  
+      const dragendEvent = createEventWithDataTransfer("dragend", dataTransfer);
+      draggable.dispatchEvent(dragendEvent);
+      }, 0);
   }
 
 

--- a/src/html_dnd.ts
+++ b/src/html_dnd.ts
@@ -20,18 +20,22 @@ namespace dnd {
   
       const dragOverEvent = createEventWithDataTransfer("dragover", dataTransfer);
       droppable.dispatchEvent(dragOverEvent);
-  
-      const dropEvent = createEventWithDataTransfer("drop", dataTransfer);
-      droppable.dispatchEvent(dropEvent);
-  
-      // For all other events. The formats and kinds in the drag data store list
-      // of items representing dragged data can be enumerated, but the data itself
-      // is unavailable and no new data can be added.
-      store.mode = "protected";
-  
-      const dragendEvent = createEventWithDataTransfer("dragend", dataTransfer);
-      draggable.dispatchEvent(dragendEvent);
+      
+      setTimeout(() => {
+        const dropEvent = createEventWithDataTransfer("drop", dataTransfer);
+        droppable.dispatchEvent(dropEvent);
+
+        // For all other events. The formats and kinds in the drag data store list
+        // of items representing dragged data can be enumerated, but the data itself
+        // is unavailable and no new data can be added.
+        store.mode = "protected";
+    
+        setTimeout(() => {
+          const dragendEvent = createEventWithDataTransfer("dragend", dataTransfer);
+          draggable.dispatchEvent(dragendEvent);
+        }, 0);
       }, 0);
+    }, 0);
   }
 
 


### PR DESCRIPTION
This fix is for handing over the dragover and drop event to the event queue, so that any function call the user had dragStart will be executed before the drop happens in the simulate function.