### PR TITLE
Fix #30 Add readFileSync encoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var Path = require('path');
 
 var BASE_DIR = __dirname;
 var CODE_FILE = Path.join(BASE_DIR, '..', 'dist', 'html_dnd.js');
-var coreCode = fs.readFileSync(CODE_FILE);
+var coreCode = fs.readFileSync(CODE_FILE, {encoding: 'utf8'});
 
 exports.code = util.format(multiline(function() {/*
   (function(draggable, droppable) {


### PR DESCRIPTION
Using this library with a new version of node returns the following error:

`Error while running .executeScript() protocol action: unknown error: Runtime.evaluate threw exception: SyntaxError: Unexpected token <`

See #30 

If you follow the instructions in https://github.com/html-dnd/html-dnd/issues/30#issuecomment-509563741

The console prints

`<Buffer ` followed by a series of numbers. I tested the fix from this comment, adding the options with utf-8 encoding and the error went away. (Using nightwatch)

This PR adds the option with encoding set to UTF-8
https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options

