### PR TITLE
Scenario: Do not finish the drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ driver.executeScript(dragAndDrop, draggable, droppable);
 
 ### Only Hover
 
-In some scenarios a drag operation is not beeing ended with a drop, but rather reveals an element upon hovering above a trigger. If you only want to do a hover you cann do so via
+In some scenarios a drag operation is not beeing ended with a drop, but rather reveals an element upon hovering above a trigger. If you only want to do a hover you can do so via
 
 ```typescript
 import {code as dragAndDrop} from 'html-dnd';

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ driver.executeScript(dragAndDrop, draggable, droppable);
 ```
 
 
+### Only Hover
+
+In some scenarios a drag operation is not beeing ended with a drop, but rather reveals an element upon hovering above a trigger. If you only want to do a hover you cann do so via
+
+```typescript
+import {code as dragAndDrop} from 'html-dnd';
+
+driver.executeScript(dragAndDrop, draggable, droppable, {onlyHover:true, hoverTime:1000});
+```
+
 See also
 --------
 

--- a/html-dnd.d.ts
+++ b/html-dnd.d.ts
@@ -7,5 +7,6 @@ declare module 'html-dnd' {
         code: string,
         codeForSelectors: string,
     };
+
     export = htmlDnd;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,25 +8,25 @@ var CODE_FILE = Path.join(BASE_DIR, '..', 'dist', 'html_dnd.js');
 var coreCode = fs.readFileSync(CODE_FILE, {encoding: 'utf8'});
 
 exports.code = util.format(multiline(function() {/*
-  (function(draggable, droppable) {
+  (function(draggable, droppable, dragConfig) {
     %s;
-    dnd.simulate(draggable, droppable);
-  })(arguments[0], arguments[1]);
+    dnd.simulate(draggable, droppable, dragConfig);
+  })(arguments[0], arguments[1], arguments[2]);
 */}), coreCode);
 
 exports.codeForSelectors = util.format(multiline(function() {/*
-  (function(selectorDraggable, selectorDroppable) {
+  (function(selectorDraggable, selectorDroppable, dragConfig) {
     %s;
     
     var draggable = document.querySelector(selectorDraggable);
     var droppable = document.querySelector(selectorDroppable);
 
-    dnd.simulate(draggable, droppable);
-  })(arguments[0], arguments[1]);
+    dnd.simulate(draggable, droppable, dragConfig);
+  })(arguments[0], arguments[1], arguments[2]);
 */}), coreCode);
 
 exports.codeForXPaths = util.format(multiline(function() {/*
-  (function(selectorDraggable, selectorDroppable) {
+  (function(selectorDraggable, selectorDroppable, dragConfig) {
     %s;
     
     var draggable = document.evaluate(selectorDraggable, document, null,
@@ -34,6 +34,6 @@ exports.codeForXPaths = util.format(multiline(function() {/*
     var droppable = document.evaluate(selectorDroppable, document, null,
                     XPathResult.ORDERED_NODE_ITERATOR_TYPE, null).iterateNext();
 
-    dnd.simulate(draggable, droppable);
-  })(arguments[0], arguments[1]);
+    dnd.simulate(draggable, droppable, dragConfig);
+  })(arguments[0], arguments[1], arguments[2]);
 */}), coreCode);


### PR DESCRIPTION
Atm wdio5 (or rather the vendor specific webdrivers) still seem to not support creating native dnd events. So i came across this util but needed a bit more.

In our testscenarios we can drag over a tree that will reveal its nodes upon hovering. To tests this beahviour i added the possibility to not do a drop, but rather end the drag operation after some configurable delay without a drop.

